### PR TITLE
Wrong import causes dependency get failure

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -2,7 +2,7 @@ package jwt
 
 import (
 	"github.com/dgrijalva/jwt-go"
-	jwtmiddleware "github.com/iris-contrib/middleware.v4/jwt"
+	jwtmiddleware "gopkg.in/iris-contrib/middleware.v4/jwt"
 	"gopkg.in/kataras/iris.v4"
 	"testing"
 )


### PR DESCRIPTION
Use `gopkg.in/iris-contrib/middleware.v4/jwt` instead of `github.com/iris-contrib/middleware.v4/jwt`

Not doing so causes a go get dependency failure.