### PR TITLE
Fix up for CORS Middleware

### DIFF
--- a/cors/cors.go
+++ b/cors/cors.go
@@ -37,15 +37,15 @@ func MakeFallbackHandler(cors_handler context.Handler) context.Handler {
 	}
 }
 
-// New returns a new cors per-route handler with the provided options.
-// Unlike the cors wrapper, this handler can be registered to specific routes.
+// New returns a new cors per-route middleware with the provided options.
+// Unlike the cors wrapper, this middleware can be registered to specific routes.
 func New(opts Options) context.Handler {
 	h := handlerconv.FromStdWithNext(WrapNext(opts))
 	return h
 }
 
-// NewAllowAll returns a new cors per-route handler with all permissions.
-// Unlike the cors wrapper, this handler can be registered to specific routes.
+// NewAllowAll returns a new cors per-route middleware with all permissions.
+// Unlike the cors wrapper, this middleware can be registered to specific routes.
 func NewAllowAll() context.Handler {
 	return handlerconv.FromStdWithNext(cors.AllowAll().ServeHTTP)
 }
@@ -116,7 +116,7 @@ func NewDefaultPartyMiddleware() router.PartyConfigurator {
 	}
 }
 
-// Default returns a new cors per-route handler with the default settings:
+// Default returns a new cors per-route middleware with the default settings:
 // allow all origins, allow methods: GET and POST
 func Default() context.Handler {
 	return New(Options{})

--- a/cors/cors.go
+++ b/cors/cors.go
@@ -66,7 +66,7 @@ func NewPartyMiddleware(opts Options) router.PartyConfigurator {
 	}
 }
 
-func NewAppAllowAllMiddleware() iris.Configurator {
+func NewAllowAllAppMiddleware() iris.Configurator {
 	return func(app *iris.Application) {
 		h := NewAllowAll()
 
@@ -75,7 +75,7 @@ func NewAppAllowAllMiddleware() iris.Configurator {
 	}
 }
 
-func NewPartyAllowAllMiddleware() router.PartyConfigurator {
+func NewAllowAllPartyMiddleware() router.PartyConfigurator {
 	return func(party router.Party) {
 		h := NewAllowAll()
 


### PR DESCRIPTION
Fixes #32 
The CORS middleware has been upgraded to have a true middleware. With the new iris/core/router.PartyConfigurator, we can push CORS as a middleware which can be used in cross-domain with router fallback cases (Cases which no routes is found cause the OPTION HTTP request made by browser in heading a cross-domain request to check permission, that's the aim of this PR).