### PR TITLE
fix prometheus bucket defaults and example

### DIFF
--- a/prometheus/_example/main.go
+++ b/prometheus/_example/main.go
@@ -4,16 +4,14 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/kataras/iris"
-
 	prometheusMiddleware "github.com/iris-contrib/middleware/prometheus"
-
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/kataras/iris"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
 	app := iris.New()
-	m := prometheusMiddleware.New("serviceName", 300, 1200, 5000)
+	m := prometheusMiddleware.New("serviceName", 0.3, 1.2, 5.0)
 
 	app.Use(m.ServeHTTP)
 
@@ -31,7 +29,7 @@ func main() {
 		ctx.Writef("Slept for %d milliseconds", sleep)
 	})
 
-	app.Get("/metrics", iris.FromStd(prometheus.Handler()))
+	app.Get("/metrics", iris.FromStd(promhttp.Handler()))
 
 	// http://localhost:8080/
 	// http://localhost:8080/anotfound

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	// DefaultBuckets prometheus buckets.
-	DefaultBuckets = []float64{300, 1200, 5000}
+	// DefaultBuckets prometheus buckets in seconds.
+	DefaultBuckets = []float64{0.3, 1.2, 5.0}
 )
 
 const (


### PR DESCRIPTION
I broke the DefaultBucket latency with my last PR.  The DefaultBuckets need to be in seconds instead of milliseconds now.

Also i updated the example code.

I had to switch from using `prometheus.Handler()` to `promhttp.Handler()` because `prometheus.Handler` registers the metric `http_requests_total` automatically and throws the following error when you try to reregister it
```
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "http_requests_total", help: "Total number of HTTP requests made.", constLabels: {handler="prometheus"}, variableLabels: [method code]} has different label names or a different help string
```

it seems like using `promhttp.Handler()` is the way forward as `prometheus.Handler()` has been marked as depreciated.
- https://github.com/prometheus/client_golang/blob/bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e/prometheus/http.go#L33
- https://github.com/prometheus/client_golang/blob/bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e/prometheus/http.go#L63