### PR TITLE
Fix CSRF Cookie Path should in root

### DIFF
--- a/csrf/store.go
+++ b/csrf/store.go
@@ -108,6 +108,7 @@ func (cs *cookieStore) Save(ctx iris.Context, token []byte) (err error) {
 	}
 
 	cookie := cs.options
+	cookie.Path = "/"
 	cookie.Value = value
 	// Set the Expires field on the cookie based on the MaxAge
 	// If MaxAge <= 0, we don't set the Expires attribute, making the cookie


### PR DESCRIPTION
CSRF cookie path not seting. if request url path not same.the cookie will be in every path set。CSRF valid fail.